### PR TITLE
chore: add run-lint.sh helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ docker run --rm \
 
 ---
 
+## Convenience Scripts
+
+- `./scripts/run-lint.sh` — run `ansible-lint` inside the containerized-ansible image against the current repo (or specified paths).
+
 ## Convenience Functions
 
 To make working with containerized Ansible easier, source the provided aliases:

--- a/scripts/bootstrap-playbook.sh
+++ b/scripts/bootstrap-playbook.sh
@@ -383,7 +383,7 @@ EOF
 # Create requirements.yaml for collections
 cat > "$PROJECT_DIR/collections/requirements.yaml" << 'EOF'
 ---
-collections:
+collections: []
   # Example collections
   # - name: community.general
   #   version: ">=1.0.0"

--- a/scripts/bootstrap-playbook.sh
+++ b/scripts/bootstrap-playbook.sh
@@ -58,6 +58,20 @@ pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 EOF
 
+# Create ansible-lint config
+# Keep linting focused on playbook repo content (not vendored roles/collections).
+cat > "$PROJECT_DIR/.ansible-lint" << 'EOF'
+---
+profile: basic
+
+exclude_paths:
+  - roles/
+  - collections/
+  - artifacts/
+  - .ssh-container/
+  - .git/
+EOF
+
 # Create inventory.yaml template
 # NOTE: when running playbooks from inside Docker on macOS, the host is reachable at host.docker.internal
 cat > "$PROJECT_DIR/inventory.yaml" << 'EOF'

--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run ansible-lint inside the containerized-ansible image.
+#
+# Usage:
+#   ./scripts/run-lint.sh [PATHS...]
+#
+# If no paths are provided, it lints the current working directory.
+
+IMAGE=${IMAGE:-"containerized-ansible:latest"}
+
+# If caller passed explicit lint targets, use them; otherwise lint repo root.
+LINT_PATHS=("$@")
+if [[ ${#LINT_PATHS[@]} -eq 0 ]]; then
+  LINT_PATHS=(".")
+fi
+
+# Run from repo root on the host.
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+exec docker run --rm -t \
+  -v "${REPO_ROOT}:/ansible" \
+  -w /ansible \
+  "${IMAGE}" \
+  ansible-lint "${LINT_PATHS[@]}"


### PR DESCRIPTION
Adds ./scripts/run-lint.sh to run ansible-lint inside the containerized-ansible image, keeping local and CI lint behavior consistent.